### PR TITLE
add missing cloud resource cr state alerts to alert exists tests

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -239,6 +239,102 @@ var expectedRules = []alertsTestRule{
 		File:  "redhat-rhmi-amq-online-enmasse-console-rules.yaml",
 		Rules: []string{},
 	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-fuse-postgres-rhmi.yaml",
+		Rules: []string{
+			"Fuse-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-threescale-redis-rhmi.yaml",
+		Rules: []string{
+			"Threescale-Redis-RhmiRedisResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-ups-postgres-rhmi.yaml",
+		Rules: []string{
+			"Ups-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-rhssouser-postgres-rhmi.yaml",
+		Rules: []string{
+			"Rhssouser-Postgres-RhmiPostgresResourceStatusPhasePending",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-rhsso-postgres-rhmi.yaml",
+		Rules: []string{
+			"Rhsso-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-ups-postgres-rhmi.yaml",
+		Rules: []string{
+			"Ups-Postgres-RhmiPostgresResourceStatusPhasePending",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-threescale-postgres-rhmi.yaml",
+		Rules: []string{
+			"Threescale-Postgres-RhmiPostgresResourceStatusPhasePending",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-fuse-postgres-rhmi.yaml",
+		Rules: []string{
+			"Fuse-Postgres-RhmiPostgresResourceStatusPhasePending",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-threescale-redis-rhmi.yaml",
+		Rules: []string{
+			"Threescale-Redis-RhmiRedisResourceStatusPhasePending",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-rhsso-postgres-rhmi.yaml",
+		Rules: []string{
+			"Rhsso-Postgres-RhmiPostgresResourceStatusPhasePending",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-threescale-backend-redis-rhmi.yaml",
+		Rules: []string{
+			"Threescale-Backend-Redis-RhmiRedisResourceStatusPhasePending",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-codeready-postgres-rhmi.yaml",
+		Rules: []string{
+			"Codeready-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-rhssouser-postgres-rhmi.yaml",
+		Rules: []string{
+			"Rhssouser-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-threescale-backend-redis-rhmi.yaml",
+		Rules: []string{
+			"Threescale-Backend-Redis-RhmiRedisResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-failed-rule-threescale-postgres-rhmi.yaml",
+		Rules: []string{
+			"Threescale-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-resource-status-phase-pending-rule-codeready-postgres-rhmi.yaml",
+		Rules: []string{
+			"Codeready-Postgres-RhmiPostgresResourceStatusPhasePending",
+		},
+	},
 }
 
 var expectedAWSRules = []alertsTestRule{


### PR DESCRIPTION
there are existing tests run as part of the e2e test suite to
ensure that only known alerts exist within prometheus.

ensure the new cloud resource cr state checks are included here.